### PR TITLE
Scenarios can be obsolete and not loaded through landing page after deploy

### DIFF
--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -40,7 +40,7 @@ class Scenario < ActiveRecord::Base
 
   # Returns the Scenario for a given scene ID / session ID pair.
   def self.for_session(scene_id, session_id)
-    where(scene_id: scene_id, session_id: session_id).first
+    where(scene_id: scene_id, session_id: session_id, obsolete: false).first
   end
 
   # Returns only scenarios which have either a guest name, or belong to a
@@ -62,7 +62,8 @@ class Scenario < ActiveRecord::Base
   #
   # user - A User or Guest whose scenarios are to be retrieved.
   #
-  scope :for_user, lambda { |user| where user_attribute_for(user) => user.id }
+  scope :for_user, lambda { |user| where(user_attribute_for(user) => user.id,
+                                         :obsolete => false )}
 
   # Returns scenarios which do not belong to the given user or guest. Useful
   # if chained onto a scene, for example:

--- a/db/migrate/20130916080737_add_obsolete_to_scenario.rb
+++ b/db/migrate/20130916080737_add_obsolete_to_scenario.rb
@@ -1,0 +1,5 @@
+class AddObsoleteToScenario < ActiveRecord::Migration
+  def change
+    add_column :scenarios, :obsolete, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130506165132) do
+ActiveRecord::Schema.define(:version => 20130916080737) do
 
   create_table "inputs", :force => true do |t|
     t.string "key",                      :null => false
@@ -32,8 +32,8 @@ ActiveRecord::Schema.define(:version => 20130506165132) do
 
   create_table "scenarios", :force => true do |t|
     t.integer  "user_id"
-    t.integer  "scene_id",                                            :null => false
-    t.integer  "session_id",                                          :null => false
+    t.integer  "scene_id",                                             :null => false
+    t.integer  "session_id",                                           :null => false
     t.string   "title"
     t.text     "input_values"
     t.datetime "updated_at"
@@ -44,9 +44,10 @@ ActiveRecord::Schema.define(:version => 20130506165132) do
     t.float    "renewability"
     t.datetime "created_at"
     t.string   "guest_uid",           :limit => 36
-    t.integer  "end_year",                          :default => 2030, :null => false
-    t.string   "country",             :limit => 2,  :default => "nl", :null => false
+    t.integer  "end_year",                          :default => 2030,  :null => false
+    t.string   "country",             :limit => 2,  :default => "nl",  :null => false
     t.string   "guest_name",          :limit => 50
+    t.boolean  "obsolete",                          :default => false
   end
 
   add_index "scenarios", ["session_id"], :name => "index_scenarios_on_session_id", :unique => true

--- a/lib/tasks/mark_scenarios_obsolete.rake
+++ b/lib/tasks/mark_scenarios_obsolete.rake
@@ -1,0 +1,23 @@
+namespace :etflex do
+  desc <<-DESC
+    Marks all scenarios to be obsolete. This is usually done after a deploy
+    of ETengine/ETSource that renders the scenarios obsolete or outdated.
+  DESC
+
+  task mark_scenarios_obsolete: :environment do
+    require 'etflex'
+
+    scenarios = Scenario.where(obsolete: false)
+
+    count = scenarios.count
+
+    scenarios.each do |scenario|
+      scenario.obsolete = true
+      scenario.save!
+    end
+
+    puts "I have marked #{ count } scenario(s) to be obsolete."
+    puts "Bye bye."
+
+  end
+end


### PR DESCRIPTION
Currently, a user can go to Etflex, start a scenario, come back _x_ months later and still his scenario can be loaded like nothing happened. While, in the meanwhile, we have deployed many changes that renders the scenario corrupt. 

The following rake task will mark _all_ the scenarios obsolete. We should do this when deploying @ChaelKruip.

```
bundle exec rake etflex:mark_scenarios_obsolete
```

This pull-request will close #386.
